### PR TITLE
🔥 Remove duplicate keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "discord",
     "discord",
     "dungeons",
-    "dungeons",
     "api",
     "wrapper"
   ],


### PR DESCRIPTION
`"dungeons"` was added twice, just removes one of them.

> merge-type: squash
commit-message: Remove duplicate keyword
description: * Updated package.json